### PR TITLE
TTAR-43 BaseEntity 분리

### DIFF
--- a/src/main/java/com/ttarum/common/domain/BaseEntity.java
+++ b/src/main/java/com/ttarum/common/domain/BaseEntity.java
@@ -13,18 +13,9 @@ public class BaseEntity {
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
 
-    @Column(name = "updated_at", nullable = false)
-    private Instant updatedAt;
-
     @PrePersist
     public void prePersist() {
         Instant now = Instant.now();
         this.createdAt = now;
-        this.updatedAt = now;
-    }
-
-    @PreUpdate
-    public void preUpdate() {
-        this.updatedAt = Instant.now();
     }
 }

--- a/src/main/java/com/ttarum/common/domain/BaseEntity.java
+++ b/src/main/java/com/ttarum/common/domain/BaseEntity.java
@@ -3,7 +3,6 @@ package com.ttarum.common.domain;
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 
 import java.time.Instant;
 
@@ -15,7 +14,6 @@ public class BaseEntity {
 
     @PrePersist
     public void prePersist() {
-        Instant now = Instant.now();
-        this.createdAt = now;
+        this.createdAt = Instant.now();
     }
 }

--- a/src/main/java/com/ttarum/common/domain/BaseEntity.java
+++ b/src/main/java/com/ttarum/common/domain/BaseEntity.java
@@ -7,7 +7,7 @@ import jakarta.persistence.PrePersist;
 import java.time.Instant;
 
 @MappedSuperclass
-public class BaseEntity {
+public abstract class BaseEntity {
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;

--- a/src/main/java/com/ttarum/common/domain/UpdatableEntity.java
+++ b/src/main/java/com/ttarum/common/domain/UpdatableEntity.java
@@ -8,7 +8,7 @@ import jakarta.persistence.PreUpdate;
 import java.time.Instant;
 
 @MappedSuperclass
-public class UpdatableEntity {
+public abstract class UpdatableEntity {
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;

--- a/src/main/java/com/ttarum/common/domain/UpdatableEntity.java
+++ b/src/main/java/com/ttarum/common/domain/UpdatableEntity.java
@@ -14,6 +14,7 @@ public abstract class UpdatableEntity extends BaseEntity {
 
     @Override
     public void prePersist() {
+        super.prePersist();
         this.updatedAt = Instant.now();
     }
 

--- a/src/main/java/com/ttarum/common/domain/UpdatableEntity.java
+++ b/src/main/java/com/ttarum/common/domain/UpdatableEntity.java
@@ -2,25 +2,19 @@ package com.ttarum.common.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
-import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 
 import java.time.Instant;
 
 @MappedSuperclass
-public abstract class UpdatableEntity {
-
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private Instant createdAt;
+public abstract class UpdatableEntity extends BaseEntity {
 
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
 
-    @PrePersist
+    @Override
     public void prePersist() {
-        Instant now = Instant.now();
-        this.createdAt = now;
-        this.updatedAt = now;
+        this.updatedAt = Instant.now();
     }
 
     @PreUpdate

--- a/src/main/java/com/ttarum/common/domain/UpdatableEntity.java
+++ b/src/main/java/com/ttarum/common/domain/UpdatableEntity.java
@@ -1,0 +1,30 @@
+package com.ttarum.common.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+
+import java.time.Instant;
+
+@MappedSuperclass
+public class UpdatableEntity {
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        Instant now = Instant.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = Instant.now();
+    }
+}

--- a/src/main/java/com/ttarum/inquiry/domain/Inquiry.java
+++ b/src/main/java/com/ttarum/inquiry/domain/Inquiry.java
@@ -1,11 +1,10 @@
 package com.ttarum.inquiry.domain;
 
+import com.ttarum.common.domain.BaseEntity;
 import com.ttarum.item.domain.Item;
 import com.ttarum.user.domain.User;
 import jakarta.persistence.*;
 import lombok.*;
-
-import java.time.Instant;
 
 @Builder
 @AllArgsConstructor
@@ -13,7 +12,7 @@ import java.time.Instant;
 @Getter
 @Entity
 @Table(name = "inquiry")
-public class Inquiry {
+public class Inquiry extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", columnDefinition = "int UNSIGNED not null")
@@ -36,12 +35,9 @@ public class Inquiry {
     @Column(name = "exist_answer", nullable = false)
     private Boolean existAnswer;
 
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private Instant createdAt;
-
-    @PrePersist
+    @Override
     public void prePersist() {
-        this.createdAt = Instant.now();
+        super.prePersist();
         this.existAnswer = false;
     }
 }

--- a/src/main/java/com/ttarum/inquiry/domain/InquiryAnswer.java
+++ b/src/main/java/com/ttarum/inquiry/domain/InquiryAnswer.java
@@ -1,9 +1,8 @@
 package com.ttarum.inquiry.domain;
 
+import com.ttarum.common.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-
-import java.time.Instant;
 
 @Builder
 @AllArgsConstructor
@@ -11,7 +10,7 @@ import java.time.Instant;
 @Getter
 @Entity
 @Table(name = "inquiry_answer")
-public class InquiryAnswer {
+public class InquiryAnswer extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", columnDefinition = "int UNSIGNED not null")
@@ -24,11 +23,4 @@ public class InquiryAnswer {
     @JoinColumn(name = "inquiry_id", nullable = false)
     private Inquiry inquiry;
 
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private Instant createdAt;
-
-    @PrePersist
-    public void prePersist() {
-        this.createdAt = Instant.now();
-    }
 }

--- a/src/main/java/com/ttarum/item/domain/Item.java
+++ b/src/main/java/com/ttarum/item/domain/Item.java
@@ -1,9 +1,8 @@
 package com.ttarum.item.domain;
 
+import com.ttarum.common.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-
-import java.time.Instant;
 
 @Builder
 @AllArgsConstructor
@@ -11,7 +10,7 @@ import java.time.Instant;
 @Getter
 @Entity
 @Table(name = "item")
-public class Item {
+public class Item extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", columnDefinition = "int UNSIGNED not null")
@@ -38,13 +37,5 @@ public class Item {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;
-
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private Instant createdAt;
-
-    @PrePersist
-    public void prePersist() {
-        this.createdAt = Instant.now();
-    }
 
 }

--- a/src/main/java/com/ttarum/order/domain/Order.java
+++ b/src/main/java/com/ttarum/order/domain/Order.java
@@ -1,10 +1,9 @@
 package com.ttarum.order.domain;
 
+import com.ttarum.common.domain.BaseEntity;
 import com.ttarum.user.domain.User;
 import jakarta.persistence.*;
 import lombok.*;
-
-import java.time.Instant;
 
 @Builder
 @AllArgsConstructor
@@ -12,7 +11,7 @@ import java.time.Instant;
 @Getter
 @Entity
 @Table(name = "`order`")
-public class Order {
+public class Order extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", columnDefinition = "int UNSIGNED not null")
@@ -36,15 +35,8 @@ public class Order {
     @Column(name = "price", columnDefinition = "int UNSIGNED not null")
     private Long price;
 
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private Instant createdAt;
-
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id", nullable = false, referencedColumnName = "id")
     private User user;
 
-    @PrePersist
-    public void prePersist() {
-        this.createdAt = Instant.now();
-    }
 }

--- a/src/main/java/com/ttarum/review/domain/Review.java
+++ b/src/main/java/com/ttarum/review/domain/Review.java
@@ -1,6 +1,7 @@
 package com.ttarum.review.domain;
 
 import com.ttarum.common.domain.BaseEntity;
+import com.ttarum.common.domain.UpdatableEntity;
 import com.ttarum.item.domain.Item;
 import com.ttarum.user.domain.User;
 import jakarta.persistence.*;
@@ -12,7 +13,7 @@ import lombok.*;
 @Getter
 @Entity
 @Table(name = "review")
-public class Review extends BaseEntity {
+public class Review extends UpdatableEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", columnDefinition = "int UNSIGNED not null")

--- a/src/main/java/com/ttarum/user/domain/User.java
+++ b/src/main/java/com/ttarum/user/domain/User.java
@@ -1,6 +1,7 @@
 package com.ttarum.user.domain;
 
 import com.ttarum.common.domain.BaseEntity;
+import com.ttarum.common.domain.UpdatableEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -13,7 +14,7 @@ import java.util.List;
 @Getter
 @Entity
 @Table(name = "user")
-public class User extends BaseEntity {
+public class User extends UpdatableEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", columnDefinition = "int UNSIGNED not null")


### PR DESCRIPTION
# Goal
- `BaseEntity`로부터 `UpdatableEntity`를 분리한다.
- `createdAt` 필드를 가지고 있는 엔티티가 `BaseEntity`를 상속하도록 수정한다.