### PR TITLE
TTAR-53 User entity 수정

### DIFF
--- a/src/main/java/com/ttarum/user/domain/NormalUser.java
+++ b/src/main/java/com/ttarum/user/domain/NormalUser.java
@@ -11,12 +11,11 @@ import lombok.*;
 @Table(name = "normal_user")
 public class NormalUser {
     @Id
-    @Column(name = "id", columnDefinition = "int UNSIGNED not null")
     private Long id;
 
     @MapsId
     @OneToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "id", nullable = false, referencedColumnName = "id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @Column(name = "login_id", nullable = false, length = 20)

--- a/src/main/java/com/ttarum/user/domain/OauthUser.java
+++ b/src/main/java/com/ttarum/user/domain/OauthUser.java
@@ -11,12 +11,11 @@ import lombok.*;
 @Table(name = "oauth_user")
 public class OauthUser {
     @Id
-    @Column(name = "id", columnDefinition = "int UNSIGNED not null")
     private Long id;
 
     @MapsId
     @OneToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "id", nullable = false, referencedColumnName = "id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @Column(name = "email", nullable = false, length = 320)


### PR DESCRIPTION
# Goal
- NormalUser, OauthUser 엔티티를 수정한다.
  - DB에 존재하지 않는 컬럼 `id`를 삭제한다.
  - `referencedColumnName`을 제거한다. (default mapping은 해당 entity의 PK이다.)