### PR TITLE
TTAR-71 S3 Service 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
 
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+	// aws:s3
+	implementation 'software.amazon.awssdk:s3:2.23.14'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ttarum/s3/component/S3Component.java
+++ b/src/main/java/com/ttarum/s3/component/S3Component.java
@@ -1,0 +1,39 @@
+package com.ttarum.s3.component;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.net.URL;
+import java.util.UUID;
+
+@Component
+public class S3Component {
+    private final S3Client s3Client;
+    private final String bucketName = "ttarum-bucket";
+
+    public S3Component(@Value("${cloud.aws.credentials.accessKey}") String accessKey,
+                       @Value("${cloud.aws.credentials.secretKey}") String secretKey,
+                       @Value("${cloud.aws.region.static}") String region) {
+        this.s3Client = S3Client.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
+                .region(Region.of(region))
+                .build();
+    }
+
+    public URL uploadImage(byte[] imageBytes, String originalFilename) {
+        String key = UUID.randomUUID() + "_" + originalFilename;
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .build();
+
+        s3Client.putObject(putObjectRequest, software.amazon.awssdk.core.sync.RequestBody.fromBytes(imageBytes));
+        return s3Client.utilities().getUrl(builder -> builder.bucket(bucketName).key(key));
+    }
+}

--- a/src/main/java/com/ttarum/s3/component/S3Component.java
+++ b/src/main/java/com/ttarum/s3/component/S3Component.java
@@ -25,8 +25,8 @@ public class S3Component {
                 .build();
     }
 
-    public URL uploadImage(byte[] imageBytes, String originalFilename) {
-        String key = UUID.randomUUID() + "_" + originalFilename;
+    public URL uploadImage(byte[] imageBytes) {
+        String key = UUID.randomUUID().toString();
 
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                 .bucket(bucketName)

--- a/src/main/java/com/ttarum/s3/service/ImageService.java
+++ b/src/main/java/com/ttarum/s3/service/ImageService.java
@@ -1,0 +1,23 @@
+package com.ttarum.s3.service;
+
+import com.ttarum.s3.component.S3Component;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.net.URL;
+
+@Service
+public class ImageService {
+    private final S3Component s3Component;
+
+    public ImageService(S3Component s3Component) {
+        this.s3Component = s3Component;
+    }
+
+    public URL saveImage(MultipartFile file) throws IOException {
+        byte[] imageBytes = file.getBytes();
+        String originalFilename = file.getOriginalFilename();
+        return s3Component.uploadImage(imageBytes, originalFilename);
+    }
+}

--- a/src/main/java/com/ttarum/s3/service/ImageService.java
+++ b/src/main/java/com/ttarum/s3/service/ImageService.java
@@ -16,7 +16,6 @@ public class ImageService {
     }
 
     public URL saveImage(MultipartFile file) throws IOException {
-        byte[] imageBytes = file.getBytes();
-        return s3Component.uploadImage(imageBytes);
+        return s3Component.uploadImage(file.getBytes());
     }
 }

--- a/src/main/java/com/ttarum/s3/service/ImageService.java
+++ b/src/main/java/com/ttarum/s3/service/ImageService.java
@@ -17,7 +17,6 @@ public class ImageService {
 
     public URL saveImage(MultipartFile file) throws IOException {
         byte[] imageBytes = file.getBytes();
-        String originalFilename = file.getOriginalFilename();
-        return s3Component.uploadImage(imageBytes, originalFilename);
+        return s3Component.uploadImage(imageBytes);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,3 +21,8 @@ jwt.secret-key=${JWT_SECRET_KEY}
 spring.data.redis.host=${REDIS_HOST}
 spring.data.redis.port=${REDIS_PORT}
 spring.data.redis.password=${REDIS_PASSWORD}
+
+# s3
+cloud.aws.credentials.accessKey=${AWS_ACCESS_KEY}
+cloud.aws.credentials.secretKey=${AWS_SECRET_KEY}
+cloud.aws.region.static=ap-northeast-2

--- a/src/test/java/com/ttarum/s3/service/ImageServiceTest.java
+++ b/src/test/java/com/ttarum/s3/service/ImageServiceTest.java
@@ -1,0 +1,41 @@
+package com.ttarum.s3.service;
+
+import com.ttarum.s3.component.S3Component;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.net.URL;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ImageServiceTest {
+    @Mock
+    private S3Component s3Component;
+
+    @InjectMocks
+    private ImageService imageService;
+
+    @Test
+    void whenSaveImage_thenS3ComponentUploadImageAndReturnUrl() throws IOException {
+        // given
+        MultipartFile file = new MockMultipartFile("file", "test.jpg", "image/jpeg", "test data".getBytes());
+        URL expectedUrl = new URL("https://ttarum-bucket.s3.ap-northeast-2.amazonaws.com/uuid_test.jpg");
+        when(s3Component.uploadImage(file.getBytes(), file.getOriginalFilename()))
+                .thenReturn(expectedUrl);
+
+        // when
+        URL resultUrl = imageService.saveImage(file);
+
+        // then
+        assertEquals(expectedUrl, resultUrl, "The URL is returned from S3Component.uploadImage()");
+    }
+
+}

--- a/src/test/java/com/ttarum/s3/service/ImageServiceTest.java
+++ b/src/test/java/com/ttarum/s3/service/ImageServiceTest.java
@@ -28,7 +28,7 @@ class ImageServiceTest {
         // given
         MultipartFile file = new MockMultipartFile("file", "test.jpg", "image/jpeg", "test data".getBytes());
         URL expectedUrl = new URL("https://ttarum-bucket.s3.ap-northeast-2.amazonaws.com/uuid_test.jpg");
-        when(s3Component.uploadImage(file.getBytes(), file.getOriginalFilename()))
+        when(s3Component.uploadImage(file.getBytes()))
                 .thenReturn(expectedUrl);
 
         // when


### PR DESCRIPTION
# 사용 방법
`ImageService.uploadImage()` 에 `(imageBytes, originalFilename)` 을 전달해주시면 S3에 저장한 후 해당 이미지의 URL을 반환합니다.

추후 Bulk upload 기능도 구현하겠습니다.

originalFilename이 postfix로 붙는데, 만약 필요 없다고 생각되시면 말씀주세요~
(지금 보니 필요 없는 것 같기도 하네요)

# env
`${AWS_ACCESS_KEY}`, `${AWS_SECRET_KEY}`는 slack으로 전달드리겠습니다.
