### PR TITLE
TTAR-058 DTO에서 Entity로 변환 메서드 이름 toXXXEntity로 통일

### DIFF
--- a/src/main/java/com/ttarum/inquiry/dto/request/InquiryCreationRequest.java
+++ b/src/main/java/com/ttarum/inquiry/dto/request/InquiryCreationRequest.java
@@ -15,7 +15,7 @@ public class InquiryCreationRequest {
     private final boolean isSecret;
     private final long itemId;
 
-    public Inquiry transferToInquiry() {
+    public Inquiry toInquiryEntity() {
         Inquiry inquiry = Inquiry.builder()
                 .title(this.title)
                 .content(this.content)

--- a/src/main/java/com/ttarum/inquiry/service/InquiryService.java
+++ b/src/main/java/com/ttarum/inquiry/service/InquiryService.java
@@ -167,7 +167,7 @@ public class InquiryService {
      */
     @Transactional
     public long postInquiryArticle(final InquiryCreationRequest request, final long memberId) {
-        Inquiry inquiry = request.transferToInquiry();
+        Inquiry inquiry = request.toInquiryEntity();
         Item item = getItemById(request);
         Member member = getMemberById(memberId);
         inquiry.setMember(member);

--- a/src/test/java/com/ttarum/inquiry/dto/request/InquiryCreationRequestTest.java
+++ b/src/test/java/com/ttarum/inquiry/dto/request/InquiryCreationRequestTest.java
@@ -20,7 +20,7 @@ class InquiryCreationRequestTest {
                 .build();
 
         // when
-        Inquiry inquiry = inquiryCreationRequest.transferToInquiry();
+        Inquiry inquiry = inquiryCreationRequest.toInquiryEntity();
 
         // then
         assertThat(inquiry.getTitle()).isEqualTo(inquiryCreationRequest.getTitle());
@@ -41,7 +41,7 @@ class InquiryCreationRequestTest {
         // when
 
         // then
-        assertThatThrownBy(inquiryCreationRequest::transferToInquiry)
+        assertThatThrownBy(inquiryCreationRequest::toInquiryEntity)
                 .isInstanceOf(InquiryException.class)
                 .hasMessage("제목이 비어있습니다.");
     }
@@ -59,7 +59,7 @@ class InquiryCreationRequestTest {
         // when
 
         // then
-        assertThatThrownBy(inquiryCreationRequest::transferToInquiry)
+        assertThatThrownBy(inquiryCreationRequest::toInquiryEntity)
                 .isInstanceOf(InquiryException.class)
                 .hasMessage("제목이 비어있습니다.");
     }
@@ -77,7 +77,7 @@ class InquiryCreationRequestTest {
         // when
 
         // then
-        assertThatThrownBy(inquiryCreationRequest::transferToInquiry)
+        assertThatThrownBy(inquiryCreationRequest::toInquiryEntity)
                 .isInstanceOf(InquiryException.class)
                 .hasMessage("내용이 비어있습니다.");
     }
@@ -95,7 +95,7 @@ class InquiryCreationRequestTest {
         // when
 
         // then
-        assertThatThrownBy(inquiryCreationRequest::transferToInquiry)
+        assertThatThrownBy(inquiryCreationRequest::toInquiryEntity)
                 .isInstanceOf(InquiryException.class)
                 .hasMessage("내용이 비어있습니다.");
     }


### PR DESCRIPTION
## Tasks

- `InquiryCreationRequest`의 `transferToInquiry` 메서드 명을 `toInquiryEntity`으로 변경했습니다.