### PR TITLE
TTAR-064 InquiryRepository의 도메인에 맞지 않는 쿼리 분리

### DIFF
--- a/src/main/java/com/ttarum/inquiry/dto/response/InquirySummaryResponse.java
+++ b/src/main/java/com/ttarum/inquiry/dto/response/InquirySummaryResponse.java
@@ -13,7 +13,7 @@ import java.time.Instant;
 @Schema(description = "문의글 미리보기 DTO")
 public class InquirySummaryResponse {
 
-    private static final String SECRET_INQUIRY_TITLE = "비밀글입니다.";
+    public static final String SECRET_INQUIRY_TITLE = "비밀글입니다.";
 
     @Schema(description = "문의글 Id 값", example = "1")
     private final Long id;

--- a/src/main/java/com/ttarum/inquiry/repository/InquiryAnswerRepository.java
+++ b/src/main/java/com/ttarum/inquiry/repository/InquiryAnswerRepository.java
@@ -1,0 +1,20 @@
+package com.ttarum.inquiry.repository;
+
+import com.ttarum.inquiry.domain.InquiryAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface InquiryAnswerRepository extends JpaRepository<InquiryAnswer, Long> {
+
+    /**
+     * {@link Long inquiryId}가 Id 값인 문의글의 답변을 반환합니다.
+     *
+     * @param inquiryId 문의글의 Id 값
+     * @return {@link InquiryAnswer}
+     */
+    @Query("SELECT ia FROM InquiryAnswer ia WHERE ia.inquiry.id = :inquiryId")
+    Optional<InquiryAnswer> findAnswerByInquiryId(@Param("inquiryId") long inquiryId);
+}

--- a/src/main/java/com/ttarum/inquiry/repository/InquiryImageRepository.java
+++ b/src/main/java/com/ttarum/inquiry/repository/InquiryImageRepository.java
@@ -16,5 +16,5 @@ public interface InquiryImageRepository extends JpaRepository<InquiryImage, Long
      * @return {@link String fileUrl} 리스트
      */
     @Query("SELECT ii.fileUrl FROM InquiryImage ii WHERE ii.inquiry.id = :inquiryId")
-    List<String> findInquiryImageByInquiryId(@Param("inquiryId") long inquiryId);
+    List<String> findImageUrlsByInquiryId(@Param("inquiryId") long inquiryId);
 }

--- a/src/main/java/com/ttarum/inquiry/repository/InquiryImageRepository.java
+++ b/src/main/java/com/ttarum/inquiry/repository/InquiryImageRepository.java
@@ -2,6 +2,19 @@ package com.ttarum.inquiry.repository;
 
 import com.ttarum.inquiry.domain.InquiryImage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface InquiryImageRepository extends JpaRepository<InquiryImage, Long> {
+
+    /**
+     * {@link Long inquiryId}가 Id 값인 문의글의 {@link InquiryImage}들의 {@link String fileUrl} 리스트를 반환합니다.
+     *
+     * @param inquiryId 문의글의 Id 값
+     * @return {@link String fileUrl} 리스트
+     */
+    @Query("SELECT ii.fileUrl FROM InquiryImage ii WHERE ii.inquiry.id = :inquiryId")
+    List<String> findInquiryImageByInquiryId(@Param("inquiryId") long inquiryId);
 }

--- a/src/main/java/com/ttarum/inquiry/repository/InquiryRepository.java
+++ b/src/main/java/com/ttarum/inquiry/repository/InquiryRepository.java
@@ -1,7 +1,6 @@
 package com.ttarum.inquiry.repository;
 
 import com.ttarum.inquiry.domain.Inquiry;
-import com.ttarum.inquiry.domain.InquiryAnswer;
 import com.ttarum.inquiry.dto.response.InquirySummaryResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,7 +8,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
 
@@ -60,13 +58,4 @@ public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
             WHERE i.item_id = :itemId
             """, nativeQuery = true)
     List<InquirySummaryResponse> findInquirySummaryByItemId(@Param("itemId") long itemId, Pageable pageable);
-
-    /**
-     * {@link Long inquiryId}가 Id 값인 문의글의 답변을 반환합니다.
-     *
-     * @param inquiryId 문의글의 Id 값
-     * @return {@link InquiryAnswer}
-     */
-    @Query("SELECT ia FROM InquiryAnswer ia WHERE ia.inquiry.id = :inquiryId")
-    Optional<InquiryAnswer> findAnswerByInquiryId(@Param("inquiryId") long inquiryId);
 }

--- a/src/main/java/com/ttarum/inquiry/repository/InquiryRepository.java
+++ b/src/main/java/com/ttarum/inquiry/repository/InquiryRepository.java
@@ -3,7 +3,6 @@ package com.ttarum.inquiry.repository;
 import com.ttarum.inquiry.domain.Inquiry;
 import com.ttarum.inquiry.domain.InquiryAnswer;
 import com.ttarum.inquiry.dto.response.InquirySummaryResponse;
-import com.ttarum.inquiry.domain.InquiryImage;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -63,15 +62,6 @@ public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
     List<InquirySummaryResponse> findInquirySummaryByItemId(@Param("itemId") long itemId, Pageable pageable);
 
     /**
-     * {@link Long inquiryId}가 Id 값인 문의글의 {@link InquiryImage}들의 {@link String fileUrl} 리스트를 반환합니다.
-     *
-     * @param inquiryId 문의글의 Id 값
-     * @return {@link String fileUrl} 리스트
-     */
-    @Query("SELECT ii.fileUrl FROM InquiryImage ii WHERE ii.inquiry.id = :inquiryId")
-    List<String> findInquiryImageByInquiryId(@Param("inquiryId") long inquiryId);
-
-    /**
      * {@link Long inquiryId}가 Id 값인 문의글의 답변을 반환합니다.
      *
      * @param inquiryId 문의글의 Id 값
@@ -79,5 +69,4 @@ public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
      */
     @Query("SELECT ia FROM InquiryAnswer ia WHERE ia.inquiry.id = :inquiryId")
     Optional<InquiryAnswer> findAnswerByInquiryId(@Param("inquiryId") long inquiryId);
-
 }

--- a/src/main/java/com/ttarum/inquiry/service/InquiryService.java
+++ b/src/main/java/com/ttarum/inquiry/service/InquiryService.java
@@ -11,6 +11,7 @@ import com.ttarum.inquiry.exception.InquiryException;
 import com.ttarum.inquiry.dto.request.InquiryCreationRequest;
 import com.ttarum.inquiry.exception.InquiryForbiddenException;
 import com.ttarum.inquiry.exception.InquiryNotFoundException;
+import com.ttarum.inquiry.repository.InquiryImageRepository;
 import com.ttarum.inquiry.repository.InquiryRepository;
 import com.ttarum.item.domain.Item;
 import com.ttarum.item.exception.ItemNotFoundException;
@@ -34,6 +35,7 @@ import java.util.Optional;
 public class InquiryService {
 
     private final InquiryRepository inquiryRepository;
+    private final InquiryImageRepository inquiryImageRepository;
     private final ItemRepository itemRepository;
     private final MemberRepository memberRepository;
 
@@ -99,7 +101,7 @@ public class InquiryService {
         }
         InquiryDetailedResponse response = InquiryDetailedResponse.of(inquiry, inquiryAnswerResponse);
 
-        List<String> imageUrls = inquiryRepository.findInquiryImageByInquiryId(inquiryId);
+        List<String> imageUrls = inquiryImageRepository.findInquiryImageByInquiryId(inquiryId);
         for (String imageUrl : imageUrls) {
             response.addImageUrl(imageUrl);
         }
@@ -144,7 +146,7 @@ public class InquiryService {
         }
         InquiryDetailedResponse response = InquiryDetailedResponse.of(inquiry, inquiryAnswerResponse);
 
-        List<String> imageUrls = inquiryRepository.findInquiryImageByInquiryId(inquiryId);
+        List<String> imageUrls = inquiryImageRepository.findInquiryImageByInquiryId(inquiryId);
         for (String imageUrl : imageUrls) {
             response.addImageUrl(imageUrl);
         }

--- a/src/main/java/com/ttarum/inquiry/service/InquiryService.java
+++ b/src/main/java/com/ttarum/inquiry/service/InquiryService.java
@@ -11,6 +11,7 @@ import com.ttarum.inquiry.exception.InquiryException;
 import com.ttarum.inquiry.dto.request.InquiryCreationRequest;
 import com.ttarum.inquiry.exception.InquiryForbiddenException;
 import com.ttarum.inquiry.exception.InquiryNotFoundException;
+import com.ttarum.inquiry.repository.InquiryAnswerRepository;
 import com.ttarum.inquiry.repository.InquiryImageRepository;
 import com.ttarum.inquiry.repository.InquiryRepository;
 import com.ttarum.item.domain.Item;
@@ -36,6 +37,7 @@ public class InquiryService {
 
     private final InquiryRepository inquiryRepository;
     private final InquiryImageRepository inquiryImageRepository;
+    private final InquiryAnswerRepository inquiryAnswerRepository;
     private final ItemRepository itemRepository;
     private final MemberRepository memberRepository;
 
@@ -120,7 +122,7 @@ public class InquiryService {
     }
 
     private InquiryAnswer getInquiryAnswerByInquiryId(final long inquiryId) {
-        return inquiryRepository.findAnswerByInquiryId(inquiryId)
+        return inquiryAnswerRepository.findAnswerByInquiryId(inquiryId)
                 .orElseThrow(InquiryAnswerNotFoundException::new);
     }
 

--- a/src/main/java/com/ttarum/inquiry/service/InquiryService.java
+++ b/src/main/java/com/ttarum/inquiry/service/InquiryService.java
@@ -103,7 +103,7 @@ public class InquiryService {
         }
         InquiryDetailedResponse response = InquiryDetailedResponse.of(inquiry, inquiryAnswerResponse);
 
-        List<String> imageUrls = inquiryImageRepository.findInquiryImageByInquiryId(inquiryId);
+        List<String> imageUrls = inquiryImageRepository.findImageUrlsByInquiryId(inquiryId);
         for (String imageUrl : imageUrls) {
             response.addImageUrl(imageUrl);
         }
@@ -148,7 +148,7 @@ public class InquiryService {
         }
         InquiryDetailedResponse response = InquiryDetailedResponse.of(inquiry, inquiryAnswerResponse);
 
-        List<String> imageUrls = inquiryImageRepository.findInquiryImageByInquiryId(inquiryId);
+        List<String> imageUrls = inquiryImageRepository.findImageUrlsByInquiryId(inquiryId);
         for (String imageUrl : imageUrls) {
             response.addImageUrl(imageUrl);
         }

--- a/src/test/java/com/ttarum/inquiry/service/InquiryServiceTest.java
+++ b/src/test/java/com/ttarum/inquiry/service/InquiryServiceTest.java
@@ -152,7 +152,7 @@ class InquiryServiceTest {
 
         // when
         when(inquiryRepository.findById(inquiryId)).thenReturn(Optional.of(inquiry));
-        when(inquiryImageRepository.findInquiryImageByInquiryId(inquiryId)).thenReturn(imageUrls);
+        when(inquiryImageRepository.findImageUrlsByInquiryId(inquiryId)).thenReturn(imageUrls);
         InquiryDetailedResponse inquiryDetailedResponse = inquiryService.getInquiryDetailedResponse(inquiryId, memberId);
 
         // then
@@ -187,7 +187,7 @@ class InquiryServiceTest {
 
         // when
         when(inquiryRepository.findById(inquiryId)).thenReturn(Optional.of(inquiry));
-        when(inquiryImageRepository.findInquiryImageByInquiryId(inquiryId)).thenReturn(imageUrls);
+        when(inquiryImageRepository.findImageUrlsByInquiryId(inquiryId)).thenReturn(imageUrls);
         when(inquiryAnswerRepository.findAnswerByInquiryId(inquiryId)).thenReturn(Optional.of(inquiryAnswer));
         InquiryDetailedResponse inquiryDetailedResponse = inquiryService.getInquiryDetailedResponse(inquiryId, memberId);
 
@@ -222,7 +222,7 @@ class InquiryServiceTest {
 
         // when
         when(inquiryRepository.findById(inquiryId)).thenReturn(Optional.of(inquiry));
-        when(inquiryImageRepository.findInquiryImageByInquiryId(inquiryId)).thenReturn(imageUrls);
+        when(inquiryImageRepository.findImageUrlsByInquiryId(inquiryId)).thenReturn(imageUrls);
         when(inquiryAnswerRepository.findAnswerByInquiryId(inquiryId)).thenReturn(Optional.of(inquiryAnswer));
         InquiryDetailedResponse inquiryDetailedResponse = inquiryService.getInquiryDetailedResponse(inquiryId);
 
@@ -253,7 +253,7 @@ class InquiryServiceTest {
 
         // when
         when(inquiryRepository.findById(inquiryId)).thenReturn(Optional.of(inquiry));
-        when(inquiryImageRepository.findInquiryImageByInquiryId(inquiryId)).thenReturn(imageUrls);
+        when(inquiryImageRepository.findImageUrlsByInquiryId(inquiryId)).thenReturn(imageUrls);
         InquiryDetailedResponse inquiryDetailedResponse = inquiryService.getInquiryDetailedResponse(inquiryId);
 
         // then

--- a/src/test/java/com/ttarum/inquiry/service/InquiryServiceTest.java
+++ b/src/test/java/com/ttarum/inquiry/service/InquiryServiceTest.java
@@ -10,6 +10,7 @@ import com.ttarum.inquiry.dto.response.answer.InquiryAnswerNotExistResponse;
 import com.ttarum.inquiry.dto.request.InquiryCreationRequest;
 import com.ttarum.inquiry.exception.InquiryForbiddenException;
 import com.ttarum.inquiry.exception.InquiryNotFoundException;
+import com.ttarum.inquiry.repository.InquiryAnswerRepository;
 import com.ttarum.inquiry.repository.InquiryImageRepository;
 import com.ttarum.inquiry.repository.InquiryRepository;
 import com.ttarum.item.domain.Item;
@@ -43,6 +44,8 @@ class InquiryServiceTest {
     InquiryRepository inquiryRepository;
     @Mock
     InquiryImageRepository inquiryImageRepository;
+    @Mock
+    InquiryAnswerRepository inquiryAnswerRepository;
     @Mock
     MemberRepository memberRepository;
     @Mock
@@ -185,7 +188,7 @@ class InquiryServiceTest {
         // when
         when(inquiryRepository.findById(inquiryId)).thenReturn(Optional.of(inquiry));
         when(inquiryImageRepository.findInquiryImageByInquiryId(inquiryId)).thenReturn(imageUrls);
-        when(inquiryRepository.findAnswerByInquiryId(inquiryId)).thenReturn(Optional.of(inquiryAnswer));
+        when(inquiryAnswerRepository.findAnswerByInquiryId(inquiryId)).thenReturn(Optional.of(inquiryAnswer));
         InquiryDetailedResponse inquiryDetailedResponse = inquiryService.getInquiryDetailedResponse(inquiryId, memberId);
 
         // then
@@ -220,7 +223,7 @@ class InquiryServiceTest {
         // when
         when(inquiryRepository.findById(inquiryId)).thenReturn(Optional.of(inquiry));
         when(inquiryImageRepository.findInquiryImageByInquiryId(inquiryId)).thenReturn(imageUrls);
-        when(inquiryRepository.findAnswerByInquiryId(inquiryId)).thenReturn(Optional.of(inquiryAnswer));
+        when(inquiryAnswerRepository.findAnswerByInquiryId(inquiryId)).thenReturn(Optional.of(inquiryAnswer));
         InquiryDetailedResponse inquiryDetailedResponse = inquiryService.getInquiryDetailedResponse(inquiryId);
 
         // then

--- a/src/test/java/com/ttarum/inquiry/service/InquiryServiceTest.java
+++ b/src/test/java/com/ttarum/inquiry/service/InquiryServiceTest.java
@@ -10,6 +10,7 @@ import com.ttarum.inquiry.dto.response.answer.InquiryAnswerNotExistResponse;
 import com.ttarum.inquiry.dto.request.InquiryCreationRequest;
 import com.ttarum.inquiry.exception.InquiryForbiddenException;
 import com.ttarum.inquiry.exception.InquiryNotFoundException;
+import com.ttarum.inquiry.repository.InquiryImageRepository;
 import com.ttarum.inquiry.repository.InquiryRepository;
 import com.ttarum.item.domain.Item;
 import com.ttarum.item.exception.ItemNotFoundException;
@@ -40,6 +41,8 @@ class InquiryServiceTest {
 
     @Mock
     InquiryRepository inquiryRepository;
+    @Mock
+    InquiryImageRepository inquiryImageRepository;
     @Mock
     MemberRepository memberRepository;
     @Mock
@@ -146,7 +149,7 @@ class InquiryServiceTest {
 
         // when
         when(inquiryRepository.findById(inquiryId)).thenReturn(Optional.of(inquiry));
-        when(inquiryRepository.findInquiryImageByInquiryId(inquiryId)).thenReturn(imageUrls);
+        when(inquiryImageRepository.findInquiryImageByInquiryId(inquiryId)).thenReturn(imageUrls);
         InquiryDetailedResponse inquiryDetailedResponse = inquiryService.getInquiryDetailedResponse(inquiryId, memberId);
 
         // then
@@ -181,7 +184,7 @@ class InquiryServiceTest {
 
         // when
         when(inquiryRepository.findById(inquiryId)).thenReturn(Optional.of(inquiry));
-        when(inquiryRepository.findInquiryImageByInquiryId(inquiryId)).thenReturn(imageUrls);
+        when(inquiryImageRepository.findInquiryImageByInquiryId(inquiryId)).thenReturn(imageUrls);
         when(inquiryRepository.findAnswerByInquiryId(inquiryId)).thenReturn(Optional.of(inquiryAnswer));
         InquiryDetailedResponse inquiryDetailedResponse = inquiryService.getInquiryDetailedResponse(inquiryId, memberId);
 
@@ -216,7 +219,7 @@ class InquiryServiceTest {
 
         // when
         when(inquiryRepository.findById(inquiryId)).thenReturn(Optional.of(inquiry));
-        when(inquiryRepository.findInquiryImageByInquiryId(inquiryId)).thenReturn(imageUrls);
+        when(inquiryImageRepository.findInquiryImageByInquiryId(inquiryId)).thenReturn(imageUrls);
         when(inquiryRepository.findAnswerByInquiryId(inquiryId)).thenReturn(Optional.of(inquiryAnswer));
         InquiryDetailedResponse inquiryDetailedResponse = inquiryService.getInquiryDetailedResponse(inquiryId);
 
@@ -247,7 +250,7 @@ class InquiryServiceTest {
 
         // when
         when(inquiryRepository.findById(inquiryId)).thenReturn(Optional.of(inquiry));
-        when(inquiryRepository.findInquiryImageByInquiryId(inquiryId)).thenReturn(imageUrls);
+        when(inquiryImageRepository.findInquiryImageByInquiryId(inquiryId)).thenReturn(imageUrls);
         InquiryDetailedResponse inquiryDetailedResponse = inquiryService.getInquiryDetailedResponse(inquiryId);
 
         // then


### PR DESCRIPTION
# Tasks

- `InquiryRepository`의 이미지 관련 메서드 `InquiryImageRepository`로 이동.
- `InquiryRepository`의 답변 관련 메서드 `InquiryAnswerRepository`로 이동.