### PR TITLE
TTAR-067 ItemController의 getSummary 반환값 변경 & size 상수로 변경

### DIFF
--- a/src/main/java/com/ttarum/item/controller/ItemController.java
+++ b/src/main/java/com/ttarum/item/controller/ItemController.java
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-import java.util.List;
 import java.util.Optional;
 
 @Tag(name = "item", description = "제품")
@@ -57,7 +56,7 @@ public interface ItemController {
             @Parameter(name = "size", description = "한 페이지당 제품 수 (기본 값 9개)", example = "9")
     })
     @GetMapping
-    ResponseEntity<List<ItemSummaryResponse>> getSummary(@RequestParam(required = false) final String query,
+    ResponseEntity<ItemSummaryResponse> getSummary(@RequestParam(required = false) final String query,
                                                          @VerificationUser final User user,
                                                          final Optional<Integer> page,
                                                          final Optional<Integer> size);

--- a/src/main/java/com/ttarum/item/controller/ItemControllerImpl.java
+++ b/src/main/java/com/ttarum/item/controller/ItemControllerImpl.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 @RequestMapping("/api/items")
 public class ItemControllerImpl implements ItemController {
 
+    private static final int ITEM_DEFAULT_SIZE_PER_PAGE = 9;
     private final ItemService itemService;
 
     @Override
@@ -38,7 +39,7 @@ public class ItemControllerImpl implements ItemController {
             @RequestParam final Optional<Integer> page,
             @RequestParam final Optional<Integer> size
     ) {
-        PageRequest pageRequest = PageRequest.of(page.orElse(0), size.orElse(9));
+        PageRequest pageRequest = PageRequest.of(page.orElse(0), size.orElse(ITEM_DEFAULT_SIZE_PER_PAGE));
         ItemSummaryResponse response;
         if (user.isLoggedIn()) {
             response = itemService.getItemSummaryList(query, pageRequest, user.getId());

--- a/src/main/java/com/ttarum/item/controller/ItemControllerImpl.java
+++ b/src/main/java/com/ttarum/item/controller/ItemControllerImpl.java
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
 import java.util.Optional;
 
 @Slf4j
@@ -33,19 +32,19 @@ public class ItemControllerImpl implements ItemController {
 
     @Override
     @GetMapping("/list")
-    public ResponseEntity<List<ItemSummaryResponse>> getSummary(
+    public ResponseEntity<ItemSummaryResponse> getSummary(
             @RequestParam(required = false) final String query,
             @VerificationUser final User user,
             @RequestParam final Optional<Integer> page,
             @RequestParam final Optional<Integer> size
     ) {
         PageRequest pageRequest = PageRequest.of(page.orElse(0), size.orElse(9));
-        List<ItemSummaryResponse> itemSummaryList;
+        ItemSummaryResponse response;
         if (user.isLoggedIn()) {
-            itemSummaryList = itemService.getItemSummaryList(query, pageRequest, user.getId());
+            response = itemService.getItemSummaryList(query, pageRequest, user.getId());
         } else {
-            itemSummaryList = itemService.getItemSummaryList(query, pageRequest);
+            response = itemService.getItemSummaryList(query, pageRequest);
         }
-        return ResponseEntity.ok(itemSummaryList);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/ttarum/item/dto/response/ItemSummary.java
+++ b/src/main/java/com/ttarum/item/dto/response/ItemSummary.java
@@ -1,0 +1,44 @@
+package com.ttarum.item.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@Schema(description = "제품 미리보기 DTO")
+public class ItemSummary {
+
+    @Schema(description = "제품의 Id 값", example = "1")
+    private final long id;
+
+    @Schema(description = "제품 카테고리 이름", example = "레드 와인")
+    private final String categoryName;
+
+    @Schema(description = "제품 이름", example = "베반 셀러스 온토게니")
+    private final String name;
+
+    @Schema(description = "제품 가격", example = "199000")
+    private final int price;
+
+    @Schema(description = "제품 평점", example = "4.5")
+    private final double rating;
+
+    @Schema(description = "제품 미리보기 이미지 URL", example = "ttarum.image.url")
+    private final String imageUrl;
+
+    @Schema(description = "로그인을 했을 경우 해당 제품이 찜 목록에 포함되어있다면 true, 아니면 false, 로그인을 하지 않았다면 모두 false", example = "true")
+    private boolean isInWishList;
+
+    @Schema(description = "제품 생성일", example = "2024-02-23T04:32:49.584863Z")
+    private final Instant createdAt;
+
+    @Schema(description = "판매량", example = "300")
+    private final long salesVolume;
+}

--- a/src/main/java/com/ttarum/item/dto/response/ItemSummaryResponse.java
+++ b/src/main/java/com/ttarum/item/dto/response/ItemSummaryResponse.java
@@ -1,44 +1,15 @@
 package com.ttarum.item.dto.response;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
-import java.time.Instant;
+import java.util.List;
 
 @Getter
-@Setter
-@Builder
-@AllArgsConstructor
-@Schema(description = "제품 미리보기 DTO")
 public class ItemSummaryResponse {
 
-    @Schema(description = "제품의 Id 값", example = "1")
-    private final long id;
+    private final List<ItemSummary> itemSummaryResponseList;
 
-    @Schema(description = "제품 카테고리 이름", example = "레드 와인")
-    private final String categoryName;
-
-    @Schema(description = "제품 이름", example = "베반 셀러스 온토게니")
-    private final String name;
-
-    @Schema(description = "제품 가격", example = "199000")
-    private final int price;
-
-    @Schema(description = "제품 평점", example = "4.5")
-    private final double rating;
-
-    @Schema(description = "제품 미리보기 이미지 URL", example = "ttarum.image.url")
-    private final String imageUrl;
-
-    @Schema(description = "로그인을 했을 경우 해당 제품이 찜 목록에 포함되어있다면 true, 아니면 false, 로그인을 하지 않았다면 모두 false", example = "true")
-    private boolean isInWishList;
-
-    @Schema(description = "제품 생성일", example = "2024-02-23T04:32:49.584863Z")
-    private final Instant createdAt;
-
-    @Schema(description = "판매량", example = "300")
-    private final long salesVolume;
+    public ItemSummaryResponse(final List<ItemSummary> itemSummaryResponseList) {
+        this.itemSummaryResponseList = itemSummaryResponseList;
+    }
 }

--- a/src/main/java/com/ttarum/item/repository/ItemRepository.java
+++ b/src/main/java/com/ttarum/item/repository/ItemRepository.java
@@ -1,7 +1,7 @@
 package com.ttarum.item.repository;
 
 import com.ttarum.item.domain.Item;
-import com.ttarum.item.dto.response.ItemSummaryResponse;
+import com.ttarum.item.dto.response.ItemSummary;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -12,14 +12,14 @@ import java.util.List;
 public interface ItemRepository extends JpaRepository<Item, Long> {
 
     /**
-     * {@link String query}를 이름으로 포함하는 제품을 {@link ItemSummaryResponse} 리스트로 반환합니다.
+     * {@link String query}를 이름으로 포함하는 제품을 {@link ItemSummary} 리스트로 반환합니다.
      *
      * @param query    검색어
      * @param pageable pageable
-     * @return {@link ItemSummaryResponse} 리스트
+     * @return {@link ItemSummary} 리스트
      */
     @Query("""
-            SELECT new com.ttarum.item.dto.response.ItemSummaryResponse(i.id, i.category.name, i.name, i.price, AVG(r.star), i.itemImageUrl, false, i.createdAt, COUNT(oi.order.id))
+            SELECT new com.ttarum.item.dto.response.ItemSummary(i.id, i.category.name, i.name, i.price, AVG(r.star), i.itemImageUrl, false, i.createdAt, COUNT(oi.order.id))
             FROM Item i
             LEFT JOIN FETCH Review r
             ON r.item.id = i.id
@@ -28,19 +28,19 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
             WHERE i.name LIKE %:query%
             GROUP BY i.id, i.category.name, i.name, i.price, i.itemImageUrl, i.createdAt
             """)
-    List<ItemSummaryResponse> getItemSummaryListByName(@Param("query") String query, Pageable pageable);
+    List<ItemSummary> getItemSummaryListByName(@Param("query") String query, Pageable pageable);
 
     /**
-     * {@link String query}를 이름으로 포함하는 제품을 {@link ItemSummaryResponse} 리스트로 반환합니다.
+     * {@link String query}를 이름으로 포함하는 제품을 {@link ItemSummary} 리스트로 반환합니다.
      * {@link Long memberId}가 Id 값인 회원의 찜 목록에 포함 여부를 포함합니다.
      *
      * @param query    검색어
      * @param pageable pageable
      * @param memberId 회원의 Id 값
-     * @return {@link ItemSummaryResponse} 리스트
+     * @return {@link ItemSummary} 리스트
      */
     @Query("""
-            SELECT new com.ttarum.item.dto.response.ItemSummaryResponse(i.id, i.category.name, i.name, i.price, AVG(r.star), i.itemImageUrl, (COUNT(wl.id) > 0), i.createdAt, COUNT(oi.order.id))
+            SELECT new com.ttarum.item.dto.response.ItemSummary(i.id, i.category.name, i.name, i.price, AVG(r.star), i.itemImageUrl, (COUNT(wl.id) > 0), i.createdAt, COUNT(oi.order.id))
             FROM Item i
             LEFT JOIN FETCH Review r
             ON r.item.id = i.id
@@ -51,5 +51,5 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
             WHERE i.name LIKE %:query%
             GROUP BY i.id, i.category.name, i.name, i.price, i.itemImageUrl, i.createdAt
             """)
-    List<ItemSummaryResponse> getItemSummaryListByName(@Param("query") String query, Pageable pageable, @Param("memberId") Long memberId);
+    List<ItemSummary> getItemSummaryListByName(@Param("query") String query, Pageable pageable, @Param("memberId") Long memberId);
 }

--- a/src/main/java/com/ttarum/item/service/ItemService.java
+++ b/src/main/java/com/ttarum/item/service/ItemService.java
@@ -2,6 +2,7 @@ package com.ttarum.item.service;
 
 import com.ttarum.item.domain.Item;
 import com.ttarum.item.dto.response.ItemDetailResponse;
+import com.ttarum.item.dto.response.ItemSummary;
 import com.ttarum.item.dto.response.ItemSummaryResponse;
 import com.ttarum.item.exception.ItemNotFoundException;
 import com.ttarum.item.repository.ItemRepository;
@@ -48,8 +49,9 @@ public class ItemService {
      * @param pageable 페이징을 위한 정보가 담겨있는 객체
      * @return 검색된 제품 목록
      */
-    public List<ItemSummaryResponse> getItemSummaryList(final String query, final Pageable pageable) {
-        return itemRepository.getItemSummaryListByName(query, pageable);
+    public ItemSummaryResponse getItemSummaryList(final String query, final Pageable pageable) {
+        List<ItemSummary> summaryList = itemRepository.getItemSummaryListByName(query, pageable);
+        return new ItemSummaryResponse(summaryList);
     }
 
     /**
@@ -63,8 +65,9 @@ public class ItemService {
      * @param userId   로그인한 회원의 Id 값
      * @return 검색된 제품 목록
      */
-    public List<ItemSummaryResponse> getItemSummaryList(final String query, final Pageable pageable, final Long userId) {
-        return itemRepository.getItemSummaryListByName(query, pageable, userId);
+    public ItemSummaryResponse getItemSummaryList(final String query, final Pageable pageable, final Long userId) {
+        List<ItemSummary> summaryList = itemRepository.getItemSummaryListByName(query, pageable, userId);
+        return new ItemSummaryResponse(summaryList);
     }
 
     private Item getItemById(final Long id) {

--- a/src/test/java/com/ttarum/item/service/ItemServiceTest.java
+++ b/src/test/java/com/ttarum/item/service/ItemServiceTest.java
@@ -2,6 +2,7 @@ package com.ttarum.item.service;
 
 import com.ttarum.item.domain.Item;
 import com.ttarum.item.dto.response.ItemDetailResponse;
+import com.ttarum.item.dto.response.ItemSummary;
 import com.ttarum.item.dto.response.ItemSummaryResponse;
 import com.ttarum.item.exception.ItemNotFoundException;
 import com.ttarum.item.repository.ItemRepository;
@@ -65,24 +66,25 @@ class ItemServiceTest {
     @DisplayName("아이템 이름으로 아이템을 조회할 수 있다.")
     void getItemSummary() {
         // given
-        ItemSummaryResponse element = new ItemSummaryResponse(1, "sample", "sample", 13000, 2.3, "/Home/image", false, Instant.now(), 1);
-        List<ItemSummaryResponse> list = List.of(element);
+        ItemSummary element = new ItemSummary(1, "sample", "sample", 13000, 2.3, "/Home/image", false, Instant.now(), 1);
+        List<ItemSummary> list = List.of(element);
         PageRequest pageRequest = PageRequest.of(0, 10);
 
         // when
         when(itemRepository.getItemSummaryListByName("sample", pageRequest)).thenReturn(list);
-        List<ItemSummaryResponse> response = itemService.getItemSummaryList("sample", pageRequest);
+        ItemSummaryResponse response = itemService.getItemSummaryList("sample", pageRequest);
+        List<ItemSummary> summaryList = response.getItemSummaryResponseList();
 
         // then
-        assertThat(response).hasSize(1);
-        assertThat(response.get(0).getId()).isEqualTo(element.getId());
-        assertThat(response.get(0).getName()).isEqualTo(element.getName());
-        assertThat(response.get(0).getPrice()).isEqualTo(element.getPrice());
-        assertThat(response.get(0).getRating()).isEqualTo(element.getRating());
-        assertThat(response.get(0).getImageUrl()).isEqualTo(element.getImageUrl());
-        assertThat(response.get(0).getCategoryName()).isEqualTo(element.getCategoryName());
-        assertThat(response.get(0).getCreatedAt()).isEqualTo(element.getCreatedAt());
-        assertThat(response.get(0).getSalesVolume()).isEqualTo(element.getSalesVolume());
+        assertThat(summaryList).hasSize(1);
+        assertThat(summaryList.get(0).getId()).isEqualTo(element.getId());
+        assertThat(summaryList.get(0).getName()).isEqualTo(element.getName());
+        assertThat(summaryList.get(0).getPrice()).isEqualTo(element.getPrice());
+        assertThat(summaryList.get(0).getRating()).isEqualTo(element.getRating());
+        assertThat(summaryList.get(0).getImageUrl()).isEqualTo(element.getImageUrl());
+        assertThat(summaryList.get(0).getCategoryName()).isEqualTo(element.getCategoryName());
+        assertThat(summaryList.get(0).getCreatedAt()).isEqualTo(element.getCreatedAt());
+        assertThat(summaryList.get(0).getSalesVolume()).isEqualTo(element.getSalesVolume());
     }
 
     @Test
@@ -93,10 +95,11 @@ class ItemServiceTest {
         PageRequest pageRequest = PageRequest.of(0, 10);
 
         // when
-        List<ItemSummaryResponse> response = itemService.getItemSummaryList(name, pageRequest);
+        ItemSummaryResponse response = itemService.getItemSummaryList(name, pageRequest);
+        List<ItemSummary> summaryList = response.getItemSummaryResponseList();
 
         // then
-        assertThat(response).isEmpty();
+        assertThat(summaryList).isEmpty();
     }
 
     @Test
@@ -107,9 +110,10 @@ class ItemServiceTest {
         PageRequest pageRequest = PageRequest.of(0, 10);
 
         // when
-        List<ItemSummaryResponse> response = itemService.getItemSummaryList(name, pageRequest);
+        ItemSummaryResponse response = itemService.getItemSummaryList(name, pageRequest);
+        List<ItemSummary> summaryList = response.getItemSummaryResponseList();
 
         // then
-        assertThat(response).isEmpty();
+        assertThat(summaryList).isEmpty();
     }
 }


### PR DESCRIPTION
# Tasks

- `ItemController`의 `getSummary` 메서드의 반환값을 `ResponseEntity<List<ItemSummaryResponse>>`에서 `ResponseEntity<ItemSummaryResponse>`로 변경했습니다.
- `ItemController`의 `getSummary` 메서드에서 사용하는 페이지당 제품의 개수를 상수로 변경했습니다.